### PR TITLE
115 add reset password endpoint during sign in

### DIFF
--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,26 @@
+import { UserAuth } from "@/app/context/AuthContext";
+import { useState } from "react";
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState<string>("");
+  const { resetPasswordEmail } = UserAuth();
+
+  const handleSubmit = () => {
+    console.log(email);
+    resetPasswordEmail(email);
+  };
+
+  return (
+    <>
+      <form action="">
+        <input
+          type="text"
+          placeholder="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <button type="submit">Send reset request</button>
+      </form>
+    </>
+  );
+}

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -8,7 +8,6 @@ export default function ForgotPassword() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(email);
     try {
       resetPasswordEmail(email);
     } catch (error) {

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { UserAuth } from "@/app/context/AuthContext";
 import { useState } from "react";
 
@@ -5,14 +6,19 @@ export default function ForgotPassword() {
   const [email, setEmail] = useState<string>("");
   const { resetPasswordEmail } = UserAuth();
 
-  const handleSubmit = () => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     console.log(email);
-    resetPasswordEmail(email);
+    try {
+      resetPasswordEmail(email);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
     <>
-      <form action="">
+      <form action="" onSubmit={handleSubmit}>
         <input
           type="text"
           placeholder="email"

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -6,5 +6,5 @@ export default function Sigin() {
       <Auth isSignIn={true}/>
     </>
   )
-  }
+}
   

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,9 +1,11 @@
+import Link from "next/link"
 import Auth from "../../components/layouts/Auth"
 
 export default function Sigin() {
   return ( 
     <>
       <Auth isSignIn={true}/>
+      <p>Forgot your password? <Link href="/auth/forgot-password">Click here!</Link></p>
     </>
   )
 }

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -5,6 +5,7 @@ import {
   signInWithEmailAndPassword,
   onAuthStateChanged,
   signOut,
+  sendPasswordResetEmail,
 } from "firebase/auth";
 import { auth } from "../firebase/firebase";
 import {
@@ -21,6 +22,7 @@ import { User as firebaseAuthUser } from "firebase/auth";
 interface AuthContextProps {
   createUser: (email: string, password: string) => Promise<any>;
   loginUser: (email: string, password: string) => Promise<any>;
+  resetPasswordEmail: (email: string) => Promise<any>;
   logOut: () => Promise<any>;
   user: firebaseAuthUser | null;
   userEmail: string | null;
@@ -83,6 +85,10 @@ export const AuthContextProvider: React.FC<{ children: ReactNode }> = ({
     }
   };
 
+  const resetPasswordEmail = async (email: string) => {
+    return sendPasswordResetEmail(auth, email);
+  }
+
   useEffect(() => {
     const authenticatedUser = onAuthStateChanged(
       auth,
@@ -111,6 +117,7 @@ export const AuthContextProvider: React.FC<{ children: ReactNode }> = ({
         userInfo,
         retrieve,
         updateUserInfo,
+        resetPasswordEmail,
       }}
     >
       {children}


### PR DESCRIPTION
Added a reset password page that is linked to the sign-in page. The user can enter an email, and firebase will send a reset password page if that user has an account.